### PR TITLE
Add KommandMarker @DslMarker to prevent illegal DSL

### DIFF
--- a/src/main/kotlin/com/github/monun/kommand/KommandContext.kt
+++ b/src/main/kotlin/com/github/monun/kommand/KommandContext.kt
@@ -20,6 +20,7 @@ import com.github.monun.kommand.argument.KommandArgument
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 
+@KommandMarker
 class KommandContext(
     val command: Command,
     val rawArguments: Array<out String>,

--- a/src/main/kotlin/com/github/monun/kommand/KommandContext.kt
+++ b/src/main/kotlin/com/github/monun/kommand/KommandContext.kt
@@ -20,7 +20,6 @@ import com.github.monun.kommand.argument.KommandArgument
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 
-@KommandMarker
 class KommandContext(
     val command: Command,
     val rawArguments: Array<out String>,

--- a/src/main/kotlin/com/github/monun/kommand/KommandDispatcher.kt
+++ b/src/main/kotlin/com/github/monun/kommand/KommandDispatcher.kt
@@ -222,6 +222,7 @@ internal fun Kommand.computeUsages(
 //상위 명령에 executor가 존재
 //하위 명령어 없음
 
+@KommandMarker
 class KommandDispatcherBuilder(
     private val plugin: JavaPlugin
 ) {

--- a/src/main/kotlin/com/github/monun/kommand/KommandMarker.kt
+++ b/src/main/kotlin/com/github/monun/kommand/KommandMarker.kt
@@ -1,0 +1,4 @@
+package com.github.monun.kommand
+
+@DslMarker
+annotation class KommandMarker

--- a/src/main/kotlin/com/github/monun/kommand/KommandMarker.kt
+++ b/src/main/kotlin/com/github/monun/kommand/KommandMarker.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021 Noonmaru
+ *
+ *  Licensed under the General Public License, Version 3.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/gpl-3.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.github.monun.kommand
 
 @DslMarker


### PR DESCRIPTION
[@DslMarker 어노테이션](https://kotlinlang.org/docs/type-safe-builders.html#scope-control-dslmarker)을 통해 DSL 작성 중 문제가 발생하지 않도록 하는 PR입니다.   
우선 DSL이 다음과 같이 설계되었다고 해석하였습니다. (잘못된 부분이 있을 경우 피드백 부탁드립니다)
1. ```kommand()```는 ```kommand()```아래에서 호출될 수 없음.
2.  ```register()```는 ```register()``` 아래에서 호출될 수 없음.
3.  ```executes()```, ```require()```, ```permissions()```는 ① ```register()```또는 ```then()``` 바로 아래에서만 호출될 수 있으며, ② 그 아래에서는 그 어떤 DSL도 더이상 작성할 수 없음.
4.  ```require()```의 ```sender: CommandSender```와 ```executes()```의 ```ctxt: KommandContext```가 this가 아닌 it로 주어지는 것은 read-only parameter로 제공하기 위함.  

이를 구현하기 위해 해당 PR에 다음을 도입했습니다.
 * ```TerminalKommandBuilder```: ```executes()```, ```require()```, ```permissions()```의 lambda에 this로 주어지는 클래스. 이 클래스가 존재하지 않을 경우 3-② 를 위반하게 됨.
 * ```IKommandBuilder```: 현재는 존재하지 않지만, 추후 생길 수 있는 ```KommandBuilder``` context에서 참조할 수 있는 value를 ```TerminalKommandBuilder```와 공유하기 위한 인터페이스.
 * ```constructor(from: IKommandBuilder): TerminalKommandBuilder```: ```executes()```등의 함수 처리 시 this등의 ```IKommandBuilder```로부터 ```TerminalKommandBuilder```를 만들어내기 위한 생성자.
 * ```KommandMarker```: DSL Marker 어노테이션. ```KommandBuilder```, ```TerminalKommandBuilder```, ```KommandDispatcherBuilder``` 클래스에 추가됨.

해당 PR에서 해결하지 못한 부분은 다음과 같습니다.
 * 설계 1의 완전한 구현: ```JavaPlugin```에 ```@KommandMarker```을 어노테이트 하지 못하기 때문에 불가능합니다. 사용자가 직접 적용할 수 있는 방법은 다음과 같습니다.
   ```kt
   @KommandMarker
   class MyPlugin: JavaPlugin() {
       fun myFunction() {
           kommand {
               kommmand { } // Impilcit this unavailable error due to @KommandMarker at MyPlugin
           }
       }
   }
   ```

해당 PR에 대해 제가 우려하고 있는 부분은 다음과 같습니다.
 * 메모리 이슈: ```KommandBuilder```의 함수들에서 ```TerminalKommandBuilder(this)```를 참조하는 lambda를 return하는 lambda를 반환하기 때문에 이를 처리하는 과정에서 이전보다 더 많은 메모리가 사용될 가능성이 있을 것 같습니다. Kotlin Compiler를 깊게 이해하고 있지 않아 이 부분은 피드백이 필요할 것 같습니다.
   * 이를 해결하기 위해 프로젝트 전역의 permission, requirement, executor의 타입을 ```TerminalKommandBuilder```의 lambda로 전환하려고 했으나 이 경우에는 ```KommandDispatcher```에서 ```execute()```의 this (```KommandBuilder: IKommandBuilder```)를 참조해야 하기 때문에 구현의 난이도가 더 높을 것 같습니다.