### PR TITLE
:bug: 매핑 오류 수정

### DIFF
--- a/kommand-core/v1.17.1/src/main/kotlin/io/github/monun/kommand/v1_17_1/NMSKommand.kt
+++ b/kommand-core/v1.17.1/src/main/kotlin/io/github/monun/kommand/v1_17_1/NMSKommand.kt
@@ -6,12 +6,14 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import com.mojang.brigadier.builder.RequiredArgumentBuilder
 import io.github.monun.kommand.internal.*
 import net.minecraft.commands.CommandSourceStack
+import net.minecraft.server.MinecraftServer
 import org.bukkit.Bukkit
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer
 
 class NMSKommand : AbstractKommand() {
     override fun register(dispatcher: KommandDispatcherImpl, aliases: List<String>) {
-        val nms = (Bukkit.getServer() as CraftServer).server.commands.dispatcher
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val nms = server.commands.dispatcher
         val node = nms.register(dispatcher.root.convert() as LiteralArgumentBuilder<CommandSourceStack>)
         aliases.forEach { nms.register(literal(it).redirect(node)) }
     }

--- a/kommand-core/v1.17/src/main/kotlin/io/github/monun/kommand/v1_17/NMSKommand.kt
+++ b/kommand-core/v1.17/src/main/kotlin/io/github/monun/kommand/v1_17/NMSKommand.kt
@@ -6,12 +6,14 @@ import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import com.mojang.brigadier.builder.RequiredArgumentBuilder
 import io.github.monun.kommand.internal.*
 import net.minecraft.commands.CommandSourceStack
+import net.minecraft.server.MinecraftServer
 import org.bukkit.Bukkit
 import org.bukkit.craftbukkit.v1_17_R1.CraftServer
 
 class NMSKommand : AbstractKommand() {
     override fun register(dispatcher: KommandDispatcherImpl, aliases: List<String>) {
-        val nms = (Bukkit.getServer() as CraftServer).server.commands.dispatcher
+        val server: MinecraftServer = (Bukkit.getServer() as CraftServer).server
+        val nms = server.commands.dispatcher
         val node = nms.register(dispatcher.root.convert() as LiteralArgumentBuilder<CommandSourceStack>)
         aliases.forEach { nms.register(literal(it).redirect(node)) }
     }


### PR DESCRIPTION
모장 매핑 -> 스피곳 매핑 과정에서 제대로 리매핑 되지 않는 부분을 수정하였습니다.
```kotlin
(Bukkit.getServer() as CraftServer).server
```
의 타입을 MinecraftServer 로 명시적으로 둘 필요가 있을 것 같습니다.