### PR TITLE
Fix & Enhance arguments

### DIFF
--- a/kommand-api/src/main/kotlin/io/github/monun/kommand/KommandArgument.kt
+++ b/kommand-api/src/main/kotlin/io/github/monun/kommand/KommandArgument.kt
@@ -59,11 +59,11 @@ interface KommandArgumentSupport {
 
     fun int(minimum: Int = Int.MIN_VALUE, maximum: Int = Int.MAX_VALUE): KommandArgument<Int>
 
-    fun float(minimum: Float, maximum: Float): KommandArgument<Float>
+    fun float(minimum: Float = -Float.MAX_VALUE, maximum: Float = Float.MAX_VALUE): KommandArgument<Float>
 
-    fun double(minimum: Double, maximum: Double): KommandArgument<Double>
+    fun double(minimum: Double = -Double.MAX_VALUE, maximum: Double = Double.MAX_VALUE): KommandArgument<Double>
 
-    fun long(minimum: Long, maximum: Long): KommandArgument<Long>
+    fun long(minimum: Long = Long.MIN_VALUE, maximum: Long = Long.MAX_VALUE): KommandArgument<Long>
 
     fun string(type: StringType = StringType.SINGLE_WORD): KommandArgument<String>
 

--- a/kommand-api/src/main/kotlin/io/github/monun/kommand/KommandArgument.kt
+++ b/kommand-api/src/main/kotlin/io/github/monun/kommand/KommandArgument.kt
@@ -111,7 +111,7 @@ interface KommandArgumentSupport {
 
     fun intRange(): KommandArgument<IntRange>
 
-    fun doubleRange(): KommandArgument<ClosedRange<Double>>
+    fun doubleRange(): KommandArgument<ClosedFloatingPointRange<Double>>
 
     fun advancement(): KommandArgument<Advancement>
 

--- a/kommand-core/v1.17.1/src/main/kotlin/io/github/monun/kommand/v1_17_1/NMSKommandArgument.kt
+++ b/kommand-core/v1.17.1/src/main/kotlin/io/github/monun/kommand/v1_17_1/NMSKommandArgument.kt
@@ -302,12 +302,12 @@ class NMSKommandArgumentSupport : KommandArgumentSupport {
     }
 
     //float
-    override fun doubleRange(): KommandArgument<ClosedRange<Double>> {
+    override fun doubleRange(): KommandArgument<ClosedFloatingPointRange<Double>> {
         return RangeArgument.floatRange() provide { context, name ->
             val nms = RangeArgument.Floats.getRange(context, name)
-            val min = nms.min ?: Double.MIN_VALUE
+            val min = nms.min ?: -Double.MAX_VALUE
             val max = nms.max ?: Double.MAX_VALUE
-            min.rangeTo(max)
+            min..max
         }
     }
 

--- a/kommand-core/v1.17/src/main/kotlin/io/github/monun/kommand/v1_17/NMSKommandArgument.kt
+++ b/kommand-core/v1.17/src/main/kotlin/io/github/monun/kommand/v1_17/NMSKommandArgument.kt
@@ -302,12 +302,12 @@ class NMSKommandArgumentSupport : KommandArgumentSupport {
     }
 
     //float
-    override fun doubleRange(): KommandArgument<ClosedRange<Double>> {
+    override fun doubleRange(): KommandArgument<ClosedFloatingPointRange<Double>> {
         return RangeArgument.floatRange() provide { context, name ->
             val nms = RangeArgument.Floats.getRange(context, name)
-            val min = nms.min ?: Double.MIN_VALUE
+            val min = nms.min ?: -Double.MAX_VALUE
             val max = nms.max ?: Double.MAX_VALUE
-            min.rangeTo(max)
+            min..max
         }
     }
 

--- a/kommand-debug/src/main/kotlin/io/github/monun/kommand/plugin/KommandPlugin.kt
+++ b/kommand-debug/src/main/kotlin/io/github/monun/kommand/plugin/KommandPlugin.kt
@@ -30,7 +30,6 @@ import io.github.monun.kommand.wrapper.Position3D
 import io.github.monun.kommand.wrapper.Rotation
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.Component.text
-import net.md_5.bungee.api.ChatColor
 import org.bukkit.*
 import org.bukkit.block.Block
 import org.bukkit.block.data.BlockData
@@ -232,7 +231,7 @@ class KommandPlugin : JavaPlugin() {
                     then("position" to KommandArgument.blockPosition()) {
                         executes {
                             val position: BlockPosition3D by it
-                            Bukkit.broadcast(text(position.toBlock(player.world).type.translationKey))
+                            Bukkit.broadcast(text(position.toBlock(player.world).type.translationKey()))
                         }
                     }
                 }


### PR DESCRIPTION
int() 이외의 다른 원시타입 매개변수에도 기본값 제공
doubleRange() 구현체의 minimum  값이 -Double.MAX_VALUE 가 아닌 Double.MIN_VALUE 로 되어있던 문제 해결