### PR TITLE
README.md에 경고문 추가.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,10 @@ main: ...
 libraries:
   - io.github.monun:kommand-core:<version>
 ```
+#### !!주의!!
 
+* `Gradle`과 `plugin.yml`의 의존성 패키지가 다르므로 주의해주세요.
+* 모든 코드는 ShadowJar를 고려하여 작성되지 않았습니다.
 ---
 
 ### NOTE


### PR DESCRIPTION
shadowJar 안된다는거랑 gradle/plugin.yml 의존성이 다르다는 설명이 Tab에만 있고 Kommand에는 없어서
#47 과 같은 혼란이 발생하는 것 같습니다.

README에 명시하는게 좋을 것 같네요.