### PR TITLE
:recycle: Use long-standing API for fetching versions

### DIFF
--- a/kommand-api/src/main/kotlin/io/github/monun/kommand/loader/KommandLoader.kt
+++ b/kommand-api/src/main/kotlin/io/github/monun/kommand/loader/KommandLoader.kt
@@ -23,12 +23,7 @@ import java.lang.reflect.InvocationTargetException
 
 internal object KommandLoader {
     private val compatVersion by lazy {
-        "v" + with("(?<=\\(MC: )[\\d.]+?(?=\\))".toPattern().matcher(Bukkit.getVersion())) {
-            when {
-                find() -> group()
-                else -> throw NoSuchElementException("No such minecraft version exists")
-            }
-        }.replace('.', '_')
+        "v" + Bukkit.getServer().minecraftVersion.replace('.', '_')
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
This PR introduces a simpler way to fetch the Minecraft version of the server the plugin that uses the library is running on:
- Instead of deducing the Minecraft version from its Bukkit version, `Server#getMinecraftVersion` is a better method for finding the Minecraft version.